### PR TITLE
remove "!" from cmdLine to prevent repeated forcing of re-instantiation

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -190,8 +190,8 @@ Steno {
 
 		server.openBundle;
 		protect {
-			if(string[0] == $!) { this.freeAll; string = string.drop(1) };
-			if(string.last == $!) { this.freeAll; string = string.drop(-1) };
+			if(string[0] == $!) { this.freeAll; string = cmdLine = string.drop(1) };
+			if(string.last == $!) { this.freeAll; string = cmdLine = string.drop(-1) };
 			if(verbosity > 0) { string.postcs };
 			diff.value(string)
 			//diff.parse(string.as(Array), synthList.collect { |x| this.removePrefix(x.defName) }) // inefficient, but safe


### PR DESCRIPTION
this happened e.g. with 
```
t.value("!aa"); 
t.set(); // removes everything and re-instantiates synths 
t.setGlobal;  // removes everything and re-instantiates synths
```