### PR TITLE
towards fixing fading

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -243,15 +243,14 @@ Steno {
 		var n;
 		if(busIndices.isNil) {
 			// allocate busses for maxBracketDepth plus fadeBus (used in filter fades)
-			n = numChannels * (maxBracketDepth + 1);
+			n = numChannels * maxBracketDepth;
 			busIndices = server.audioBusAllocator.alloc(n);
-			if(busIndices.isNil) {
+			fadeBus = server.audioBusAllocator.alloc(numChannels);
+			if(busIndices.isNil || {fadeBus.isNil}) {
 				"not enough busses available! Please reboot the server"
 				"or increase the number of audio bus channels in ServerOptions".throw
 			};
-
-			busIndices = busIndices + (0, numChannels .. n);
-			fadeBus = busIndices.last + numChannels;
+			busIndices = busIndices + (0, numChannels .. (n-1));
 		}
 	}
 	//////////////////// getting information about the resulting synth graph ////////////
@@ -484,9 +483,9 @@ Steno {
 			signal = XFade2.ar(inputOutside, stenoSignal.input, MulAdd(stenoSignal.mix, 2, -1));
 
 			signal = Mix.ar([
-				signal, 
+				signal,
 				oldSignal * max(
-					stenoSignal.through.varlag(stenoSignal.fadeTime, start: 0), 
+					stenoSignal.through.varlag(stenoSignal.fadeTime, start: 0),
 					1 - stenoSignal.env
 				)
 			]);   // fade old input according to gate, signal is supposed to fade out itself.

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -446,12 +446,23 @@ Steno {
 	initSynthDefs {
 		var routingFunction, dummyOpeningFunction;
 		// we always go through a limiter here.
-		this.addSynthDef(\monitor, { |out, in, amp = 0.1|
+
+		// LFSaw.de -- quite heavy processing and sound shaping, I'll rather reduce the signal (since there's likely lots of summation happening) and have the intended level up.
+		// this.addSynthDef(\monitor, { |out, in, amp = 0.1|
+		// 	Out.ar(out,
+		// 		Limiter.ar(
+		// 			In.ar(in, numChannels),
+		// 			amp,
+		// 			0.1
+		// 		)
+		// 	)
+		// }, force:true);
+		this.addSynthDef(\monitor, { |out, in, amp = 0.1, level = 0.9|
 			Out.ar(out,
 				Limiter.ar(
-					In.ar(in, numChannels),
-					amp,
-					0.1
+					In.ar(in, numChannels) * amp,
+					level,
+					0.05
 				)
 			)
 		}, force:true);

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -416,11 +416,12 @@ Steno {
 			if(variables[name].isNil) {
 				"new variable as ".post;
 				this.filter(name, { |input, controls|
+					var feedback = \feedback.kr(0);
 					var bus = Bus.audio(server, numChannels);
 					var in = XFade2.ar(
 						inA: In.ar(bus, numChannels),
-						inB: InFeedback.ar(bus, numChannels) * \feedback.kr.sign,
-						pan: \feedback.kr.abs.linlin(0, 1, -1, 1)
+						inB: InFeedback.ar(bus, numChannels) * feedback.sign,
+						pan: feedback.abs.linlin(0, 1, -1, 1)
 					);
 					variables[name].free; variables[name] = bus;
 

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -246,7 +246,7 @@ Steno {
 			n = numChannels * maxBracketDepth;
 			busIndices = server.audioBusAllocator.alloc(n);
 			fadeBus = server.audioBusAllocator.alloc(numChannels);
-			if(busIndices.isNil || {fadeBus.isNil}) {
+			if(busIndices.isNil or: { fadeBus.isNil }) {
 				"not enough busses available! Please reboot the server"
 				"or increase the number of audio bus channels in ServerOptions".throw
 			};

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -417,9 +417,16 @@ Steno {
 				"new variable as ".post;
 				this.filter(name, { |input, controls|
 					var bus = Bus.audio(server, numChannels);
-					var in = XFade2.ar(In.ar(bus, numChannels), InFeedback.ar(bus, numChannels), \feedback.kr.linlin(0, 1, -1, 1));
+					var in = XFade2.ar(
+						inA: In.ar(bus, numChannels),
+						inB: InFeedback.ar(bus, numChannels) * \feedback.kr.sign,
+						pan: \feedback.kr.abs.linlin(0, 1, -1, 1)
+					);
 					variables[name].free; variables[name] = bus;
-					Out.ar(bus, input * (\tokenIndex.kr < \assignment.kr(1))); // \assignment can be increased for feeding in more than one signals
+
+					// \assignment can be increased for feeding in more than one signal
+					Out.ar(bus, input * (\tokenIndex.kr < \assignment.kr(1)));
+
 					in * controls[\env] + input
 				})
 

--- a/Classes/StenoSettings.sc
+++ b/Classes/StenoSettings.sc
@@ -3,6 +3,7 @@ StenoSettings {
 	var <globalSettings, <synthSettings, <msgFuncs, <current;
 	var <>lexicalScope = true;
 	var stack;
+	var internalArgs = #[\in, \out, \dryIn, \through, \gate, \fadeBus, \replacement];
 
 	*new { ^super.new.init }
 
@@ -32,9 +33,9 @@ StenoSettings {
 	}
 
 	addSynthDef { |name, synthDef|
-		var a = "", b = "", excluding = #[\in, \out, \dryIn, \through, \gate], count = 0;
+		var a = "", b = "", count = 0;
 		synthDef.desc.controls.do { |c|
-			if(excluding.includes(c.name).not) {
+			if(internalArgs.includes(c.name).not) {
 				a = a ++ c.name ++ " = " ++ c.defaultValue ++ ", ";
 				b = b ++ "'%', %.value(controls ? ()), ".format(c.name, c.name);
 				count = count + 1;

--- a/HelpSource/Classes/Steno.schelp
+++ b/HelpSource/Classes/Steno.schelp
@@ -490,8 +490,8 @@ definitionlist::
 ##through (1)
 || How much of the signal to its left is forwarded to the right
 
-##feedback
-|| A value between 0.0 and 1.0 determines the feedback from the last declaration to the first declaration
+##feedback (0)
+|| An attenuverter ranging between -1.0 and 1.0. Its absolute value determines the amount feedback from the right-most declaration to the left-most. If negative, the feedback is phase-inverted.
 
 ##assignment (1)
 || The number of times a variable can be assigned in succession (left to right). If the number is reached, the signal is not altered anymore. Assigned signals are mixed down to one multichannel stream.

--- a/HelpSource/Classes/Steno.schelp
+++ b/HelpSource/Classes/Steno.schelp
@@ -492,6 +492,26 @@ definitionlist::
 
 ##feedback (0)
 || An attenuverter ranging between -1.0 and 1.0. Its absolute value determines the amount feedback from the right-most declaration to the left-most. If negative, the feedback is phase-inverted.
+code::
+// Karplus-Strong
+(
+// a filter that creates an impulse
+t.filter(\i, {|in, ctls|
+  Dust2.ar(10) + DelayL.ar(in.reverse, 0.1, {Rand(0.001, 0.0005)}!2, 1)
+});
+
+// a variable
+t.declareVariables([0]);
+)
+
+// swap between one and more filters
+-- 0i0
+-- 0ii0
+
+// set feedback parameters (negative creates lower octave)
+t.set(\0, \feedback, 0.9)
+t.set(\0, \feedback, -0.9)
+::
 
 ##assignment (1)
 || The number of times a variable can be assigned in succession (left to right). If the number is reached, the signal is not altered anymore. Assigned signals are mixed down to one multichannel stream.


### PR DESCRIPTION
My test file is here:
https://gist.github.com/LFSaw/aa60234ddb04ae4c5348112ecab170d7

This PR is big and by far not ready to merge (I think). It basically are two commits, the rest are merge artefacts from branches I already proposed in other PRs (#14 #15 #16).

## 52aaf68


To fix fading behaviour to sound reasonable, I realised that an additional `numChannels`-sized bus is needed: I called it `Steno:fadeBus` (that's the index, no bus object used, I'm open for naming ideas, but I;d like to keep it reasonably short for the sake of OSC communication).

When a filter is replaced (`DiffString:swapFunc`), it sends an arg `\replacement, 1` which indicates that this filter is a replacement for an old one. This triggers that it reads its signal from `fadeBus` during the fade and switches later to normal behaviour.
All this is defined in [`StenoSignal:filterInput](https://github.com/telephon/Steno/compare/master...tai-studio:topic/fix-fading?expand=1#diff-b620583ac6429f33d6d6403eb3672339R53).

Accrodingly, all Synths need to write (i.e. `ReplaceOut`) to that bus (compare lower third of each, `StenoSignal:filterInput` and `StenoSignal:quelleInput`).



## 4fb2e1c

Since also the Synths for `[]{}()` need to write there, I made them use the StenoSignal class.

--------

## missing

+ @telephon s input :) 
+ [ ] tests for variables
+ [ ] tests for operators
