### PR TITLE
fix fading collectTails-scheme

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -243,15 +243,14 @@ Steno {
 		var n;
 		if(busIndices.isNil) {
 			// allocate busses for maxBracketDepth plus fadeBus (used in filter fades)
-			n = numChannels * (maxBracketDepth + 1);
+			n = numChannels * maxBracketDepth;
 			busIndices = server.audioBusAllocator.alloc(n);
-			if(busIndices.isNil) {
+			fadeBus = server.audioBusAllocator.alloc(numChannels);
+			if(busIndices.isNil || {fadeBus.isNil}) {
 				"not enough busses available! Please reboot the server"
 				"or increase the number of audio bus channels in ServerOptions".throw
 			};
-
-			busIndices = busIndices + (0, numChannels .. n);
-			fadeBus = busIndices.last + numChannels;
+			busIndices = busIndices + (0, numChannels .. (n-1));
 		}
 	}
 	//////////////////// getting information about the resulting synth graph ////////////
@@ -484,9 +483,9 @@ Steno {
 			signal = XFade2.ar(inputOutside, stenoSignal.input, MulAdd(stenoSignal.mix, 2, -1));
 
 			signal = Mix.ar([
-				signal, 
+				signal,
 				oldSignal * max(
-					stenoSignal.through.varlag(stenoSignal.fadeTime, start: 0), 
+					stenoSignal.through.varlag(stenoSignal.fadeTime, start: 0),
 					1 - stenoSignal.env
 				)
 			]);   // fade old input according to gate, signal is supposed to fade out itself.

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -6,7 +6,7 @@ Steno {
 	var <encyclopedia, <operators;
 	var <monitor, <diff;
 	var <busIndices, <synthList, <argList, <variables;
-	var <fadeBus;
+	var <tailBus;
 	var <>preProcessor, <>preProcess = true, <cmdLine, <rawCmdLine;
 	var <>verbosity = 1; // 0, 1, 2.
 	var <group;
@@ -242,11 +242,11 @@ Steno {
 	initBusses {
 		var n;
 		if(busIndices.isNil) {
-			// allocate busses for maxBracketDepth plus fadeBus (used in filter fades)
+			// allocate busses for maxBracketDepth plus tailBus (used in filter fades)
 			n = numChannels * maxBracketDepth;
 			busIndices = server.audioBusAllocator.alloc(n);
-			fadeBus = server.audioBusAllocator.alloc(numChannels);
-			if(busIndices.isNil or: { fadeBus.isNil }) {
+			tailBus = server.audioBusAllocator.alloc(numChannels);
+			if(busIndices.isNil or: { tailBus.isNil }) {
 				"not enough busses available! Please reboot the server"
 				"or increase the number of audio bus channels in ServerOptions".throw
 			};
@@ -612,7 +612,7 @@ Steno {
 				} {
 					args = this.calcNextArguments(token);
 					currentSynth = synthList.at(i);
-					synth = this.newSynth(token, i, args ++ [\replacement, 1], currentSynth.nodeID); // place new synth after old
+					synth = this.newSynth(token, i, args, currentSynth.nodeID); // place new synth after old
 					currentSynth.release;
 					synthList.put(i, synth);
 					argList.put(i, args);
@@ -729,7 +729,7 @@ Steno {
 		//"after %,  the argument index is %\n".postf(token, argumentStack.argumentIndex);
 		//"% args: %\n".postf(token, args);
 
-		args = settings.calcNextArguments(token, controls) ++ args  ++ [\fadeBus, fadeBus]; // append the necessary args, so they can't be overridden
+		args = settings.calcNextArguments(token, controls) ++ args  ++ [\tailBus, tailBus]; // append the necessary args, so they can't be overridden
 		//"% args: %\n".postf(token, args);
 		^args
 

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -413,15 +413,16 @@ Steno {
 
 
 	declareVariables { |names|
-		var bus;
 		names.do { |name|
 			name = name.asSymbol;
 			if(variables[name].isNil) {
 				"new variable as ".post;
-				bus = Bus.audio(server, numChannels);
 
 				this.filter(name, { |input, controls|
 					var feedback = \feedback.kr(0);
+					// Bus declaration inside synth func restores busses with
+					// correct channel numbers, e.g. when number of channels changed on the fly
+					var bus = Bus.audio(server, numChannels);
 					var in = XFade2.ar(
 						inA: In.ar(bus, numChannels),
 						inB: Limiter.ar(InFeedback.ar(bus, numChannels), 8, 0.01) * feedback.sign,

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -485,7 +485,7 @@ Steno {
 			signal = Mix.ar([
 				signal,
 				oldSignal * max(
-					stenoSignal.through.varlag(stenoSignal.fadeTime, start: 0),
+					stenoSignal.through,
 					1 - stenoSignal.env
 				)
 			]);   // fade old input according to gate, signal is supposed to fade out itself.

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -463,7 +463,7 @@ Steno {
 		this.addSynthDef(\monitor, { |out, in, amp = 0.1, level = 0.9|
 			Out.ar(out,
 				Limiter.ar(
-					In.ar(in, numChannels) * amp,
+					LeakDC.ar(In.ar(in, numChannels)) * amp,
 					level,
 					0.05
 				)

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -446,12 +446,23 @@ Steno {
 	initSynthDefs {
 		var routingFunction, dummyOpeningFunction;
 		// we always go through a limiter here.
-		this.addSynthDef(\monitor, { |out, in, amp = 0.1|
+
+		// LFSaw.de -- quite heavy processing and sound shaping, I'll rather reduce the signal (since there's likely lots of summation happening) and have the intended level up.
+		// this.addSynthDef(\monitor, { |out, in, amp = 0.1|
+		// 	Out.ar(out,
+		// 		Limiter.ar(
+		// 			In.ar(in, numChannels),
+		// 			amp,
+		// 			0.1
+		// 		)
+		// 	)
+		// }, force:true);
+		this.addSynthDef(\monitor, { |out, in, amp = 0.1, level = 0.9|
 			Out.ar(out,
 				Limiter.ar(
-					In.ar(in, numChannels),
-					amp,
-					0.1
+					In.ar(in, numChannels) * amp,
+					level,
+					0.05
 				)
 			)
 		}, force:true);

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -416,11 +416,12 @@ Steno {
 			if(variables[name].isNil) {
 				"new variable as ".post;
 				this.filter(name, { |input, controls|
+					var feedback = \feedback.kr(0);
 					var bus = Bus.audio(server, numChannels);
 					var in = XFade2.ar(
 						inA: In.ar(bus, numChannels),
-						inB: InFeedback.ar(bus, numChannels) * \feedback.kr.sign,
-						pan: \feedback.kr.abs.linlin(0, 1, -1, 1)
+						inB: InFeedback.ar(bus, numChannels) * feedback.sign,
+						pan: feedback.abs.linlin(0, 1, -1, 1)
 					);
 					variables[name].free; variables[name] = bus;
 

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -246,7 +246,7 @@ Steno {
 			n = numChannels * maxBracketDepth;
 			busIndices = server.audioBusAllocator.alloc(n);
 			fadeBus = server.audioBusAllocator.alloc(numChannels);
-			if(busIndices.isNil || {fadeBus.isNil}) {
+			if(busIndices.isNil or: { fadeBus.isNil }) {
 				"not enough busses available! Please reboot the server"
 				"or increase the number of audio bus channels in ServerOptions".throw
 			};

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -419,7 +419,6 @@ Steno {
 				"new variable as ".post;
 
 				this.filter(name, { |input, controls|
-					var feedback = \feedback.kr(0);
 					// Bus declaration inside synth func restores busses with
 					// correct channel numbers, e.g. when number of channels changed on the fly
 					var bus = Bus.audio(server, numChannels);

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -417,9 +417,16 @@ Steno {
 				"new variable as ".post;
 				this.filter(name, { |input, controls|
 					var bus = Bus.audio(server, numChannels);
-					var in = XFade2.ar(In.ar(bus, numChannels), InFeedback.ar(bus, numChannels), \feedback.kr.linlin(0, 1, -1, 1));
+					var in = XFade2.ar(
+						inA: In.ar(bus, numChannels),
+						inB: InFeedback.ar(bus, numChannels) * \feedback.kr.sign,
+						pan: \feedback.kr.abs.linlin(0, 1, -1, 1)
+					);
 					variables[name].free; variables[name] = bus;
-					Out.ar(bus, input * (\tokenIndex.kr < \assignment.kr(1))); // \assignment can be increased for feeding in more than one signals
+
+					// \assignment can be increased for feeding in more than one signal
+					Out.ar(bus, input * (\tokenIndex.kr < \assignment.kr(1)));
+
 					in * controls[\env] + input
 				})
 

--- a/Classes/StenoSettings.sc
+++ b/Classes/StenoSettings.sc
@@ -3,7 +3,7 @@ StenoSettings {
 	var <globalSettings, <synthSettings, <msgFuncs, <current;
 	var <>lexicalScope = true;
 	var stack;
-	var internalArgs = #[\in, \out, \dryIn, \through, \gate, \fadeBus, \replacement];
+	var internalArgs = #[\in, \out, \dryIn, \through, \gate, \tailBus];
 
 	*new { ^super.new.init }
 

--- a/Classes/StenoSettings.sc
+++ b/Classes/StenoSettings.sc
@@ -3,6 +3,7 @@ StenoSettings {
 	var <globalSettings, <synthSettings, <msgFuncs, <current;
 	var <>lexicalScope = true;
 	var stack;
+	var internalArgs = #[\in, \out, \dryIn, \through, \gate, \fadeBus, \replacement];
 
 	*new { ^super.new.init }
 
@@ -32,9 +33,9 @@ StenoSettings {
 	}
 
 	addSynthDef { |name, synthDef|
-		var a = "", b = "", excluding = #[\in, \out, \dryIn, \through, \gate], count = 0;
+		var a = "", b = "", count = 0;
 		synthDef.desc.controls.do { |c|
-			if(excluding.includes(c.name).not) {
+			if(internalArgs.includes(c.name).not) {
 				a = a ++ c.name ++ " = " ++ c.defaultValue ++ ", ";
 				b = b ++ "'%', %.value(controls ? ()), ".format(c.name, c.name);
 				count = count + 1;

--- a/Classes/StenoSignal.sc
+++ b/Classes/StenoSignal.sc
@@ -83,7 +83,7 @@ StenoSignal {
 
 		// gating analysis
 		gateHappened = gate <= 0;
-		dcBlocked = LeakDC.ar(signal.sum);
+		dcBlocked = LeakDC.ar(Sanitize.ar(signal.sum));
 
 		// free synth if signal constant for fadeTime:
 		DetectSilence.ar(max(gate, dcBlocked), time: fadeTime, doneAction:2);

--- a/Classes/StenoSignal.sc
+++ b/Classes/StenoSignal.sc
@@ -1,7 +1,7 @@
 
 StenoSignal {
 	var <numChannels, <multiChannelExpand;
-	var <inBus, <outBus, <env, <gate, <fadeTime, fadeEnv, <attack, <mix, <through, <dryIn;
+	var <inBus, <outBus, <env, <gate, <fadeTime, fadeEnv, <attack, <mix, <through, <dryIn, <feedback;
 	var <tailBus; // holds tails of replaced synths
 	var <synthIndex, <index, <nestingDepth, <input, <controls;
 	var outputSignals;
@@ -32,6 +32,8 @@ StenoSignal {
 		index = \index.kr(0);
 		nestingDepth = \nestingDepth.kr(0);
 
+		feedback = \feedback.kr(0);
+
 		// see also StenoStack:updateControls
 		controls = (
 			index: index,
@@ -43,7 +45,8 @@ StenoSignal {
 			through: through,
 			env: env,
 			fadeTime: fadeTime,
-			attack: attack
+			attack: attack,
+			feedback: feedback
 		);
 	}
 

--- a/HelpSource/Classes/Steno.schelp
+++ b/HelpSource/Classes/Steno.schelp
@@ -490,8 +490,8 @@ definitionlist::
 ##through (1)
 || How much of the signal to its left is forwarded to the right
 
-##feedback
-|| A value between 0.0 and 1.0 determines the feedback from the last declaration to the first declaration
+##feedback (0)
+|| An attenuverter ranging between -1.0 and 1.0. Its absolute value determines the amount feedback from the right-most declaration to the left-most. If negative, the feedback is phase-inverted.
 
 ##assignment (1)
 || The number of times a variable can be assigned in succession (left to right). If the number is reached, the signal is not altered anymore. Assigned signals are mixed down to one multichannel stream.

--- a/HelpSource/Classes/Steno.schelp
+++ b/HelpSource/Classes/Steno.schelp
@@ -492,6 +492,26 @@ definitionlist::
 
 ##feedback (0)
 || An attenuverter ranging between -1.0 and 1.0. Its absolute value determines the amount feedback from the right-most declaration to the left-most. If negative, the feedback is phase-inverted.
+code::
+// Karplus-Strong
+(
+// a filter that creates an impulse
+t.filter(\i, {|in, ctls|
+  Dust2.ar(10) + DelayL.ar(in.reverse, 0.1, {Rand(0.001, 0.0005)}!2, 1)
+});
+
+// a variable
+t.declareVariables([0]);
+)
+
+// swap between one and more filters
+-- 0i0
+-- 0ii0
+
+// set feedback parameters (negative creates lower octave)
+t.set(\0, \feedback, 0.9)
+t.set(\0, \feedback, -0.9)
+::
 
 ##assignment (1)
 || The number of times a variable can be assigned in succession (left to right). If the number is reached, the signal is not altered anymore. Assigned signals are mixed down to one multichannel stream.


### PR DESCRIPTION
<img width="880" alt="image" src="https://user-images.githubusercontent.com/75468/30079174-a261e89a-927f-11e7-857d-dabaa8cddc68.png">

Implementing collectTails scheme (see figure) for replacing Synths (`Diff:swapFunc`). 
First row is a "replacement-group" for Filter, 2nd row is a "replacement-group" for Quellen.
All Synths are instantiated in the form of the rightmost appearance (called `A` ) and, when being replaced, get a "replace" message which switches them to the layout in the left versions (called `A'` resp. `A''`).

This should allow to use `fadeTime` and `attack` to crossfade replacements.
a testcase can be found here: https://gist.github.com/LFSaw/aa60234ddb04ae4c5348112ecab170d7

the general scheme of what shoud happen during a fade is shown below:

<img width="488" alt="image" src="https://user-images.githubusercontent.com/75468/30079515-bb2bc84a-9280-11e7-8d1e-a6acab67b659.png">