### PR TITLE
steno: fix default preprocessor parentheses matching

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -58,7 +58,7 @@ Steno {
 			thisProcess.interpreter.preProcessor = { |string|
 				string = string.copy; // make it mutable
 				while { string.beginsWith("\n") } { string = string.drop(1) };
-				if(string.beginsWith("(") and: string.endsWith(")")) { string = string.drop(1).drop(-1) };
+				if(string.beginsWith("(\n--") and: string.endsWith("\n)")) { string = string.drop(2).drop(-2) };
 				if(string.beginsWith("--")) { string = "Steno.current.value(\"%\")".format(string.drop(2)) };
 				string
 			}


### PR DESCRIPTION
This fixes #4.

A valid steno string in the default preprocessor begins with `--`, also
if there are parentheses before it.