### PR TITLE
new replace all synths implementation (aka "!")

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -286,56 +286,6 @@ Steno {
 		}
 	}
 
-	// this represents the structure of the actual implementation
-	// not complete
-
-	plotStructure { |title = "untitled"|
-		var window, run = true;
-		var in, out, prevNode, curNode;
-		window = Window(title);
-		window.background = Color.black;
-		window.onClose = { run = false };
-		window.drawFunc = {
-			var prevNodes = Array.newClear(busIndices.size);
-			synthList.do { |synth, i|
-				var nodeSize = 20;
-				var args = argList.at(i);
-				var name = this.removePrefix(synth.defName);
-				var mul = Point(
-					window.bounds.width - (nodeSize * 2) / busIndices.size,
-					window.bounds.height - (nodeSize * 2) / synthList.size
-				);
-				if(args.isEmpty.not and: { name != ')' }) {
-					in = busIndices.indexOf(args[1]);
-					//in = busIndices.indexOf(args[5]);
-					out = busIndices.indexOf(args[3]);
-				} {
-					out = out ? 0;
-					in = in ? in;
-				};
-				prevNode = prevNodes[in];
-				curNode = Point(out + 1, i + 1) * mul;
-				prevNodes[out] = curNode;
-				Pen.color = Color.white;
-				Pen.moveTo(curNode);
-				Pen.addOval(Rect.aboutPoint(curNode, nodeSize, nodeSize));
-				Pen.moveTo(curNode);
-				if(name != '?') { Pen.stringAtPoint(name, curNode, Font.sansSerif(nodeSize)) };
-				Pen.moveTo(curNode);
-				prevNode !? { Pen.lineTo(prevNode) };
-			};
-			Pen.stroke;
-		};
-		{ while { run } { window.refresh; 0.05.wait; } }.fork(AppClock)
-		^window.front;
-	}
-
-	dotStructure { |title, attributes, labelAttributes|
-		attributes = attributes ?? { "rankdir=LR;\nfontname=Courier;\nlabel=\"\n\n%\"".format(cmdLine) };
-		labelAttributes = labelAttributes ?? { "fontname=Courier" };
-		^this.cmdLine.stenoDotStructure(title ? cmdLine, attributes, variables.keys, operators, labelAttributes)
-	}
-
 
 	///////////////// wrappers for UGen functions ///////////////////////
 

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -712,6 +712,7 @@ Steno {
 			']', { settings.pop; argumentStack.endParallel;},
 			'{', { settings.push; argumentStack.beginStack; },
 			'}', { settings.pop; argumentStack.endStack; },
+			'!', { argumentStack.beginReplaceAll; },
 			// default case
 			{
 				controls = argumentStack.controls;

--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -209,15 +209,19 @@ Steno {
 	}
 
 	resendSynths { |names| // names are symbols
+		var oldSynthList = synthList.copy;
+		var oldSynth;
+
 		// we use the one-to-one equivalence of synths and tokens
 		this.prevTokens.do { |token, i|
 			var newSynth, args;
 			if(names.isNil or: { names.includes(token) }) {
 				args = argList.at(i);
-				newSynth = this.newSynth(token, i, args);
+				oldSynth = oldSynthList.at(i);
+				newSynth = this.newSynth(token, nil, args, oldSynth.nodeID);
 				if(verbosity > 1) { ("replaced synth" + token).postln };
-				"releasing old synth with id: %".format(synthList.at(i)).postln;
-				synthList.at(i).release;
+				"releasing old synth with id: %".format(oldSynthList.at(i)).postln;
+				oldSynth.release;
 				synthList.put(i, newSynth);
 			}
 		}
@@ -632,7 +636,8 @@ Steno {
 		// LFSaw.de: if target not explicitely given (needed for replacement, to place new synth _after_ old):
 		// if first in list, add synth to encapsulating group
 		// otherwise add it after previous synth in list
-		target = target ?? {synthList[i - 1]};
+
+		target = target ?? { synthList[i - 1] };
 		addAction = if(target.isNil) {
 			target = group;
 			\addToHead

--- a/Classes/StenoStack.sc
+++ b/Classes/StenoStack.sc
@@ -4,7 +4,10 @@ StenoStack {
 	var argStack;
 
 	var dryReadIndex = 0, readIndex = 0, writeIndex = 0, through = 0, <argumentIndex;
-	var nestingDepth = 0, replaceAll = false;
+	var <replaceAll = false;
+
+	var nestingDepth = 0;
+
 
 
 	*new { |busIndices|
@@ -93,6 +96,7 @@ StenoStack {
 
 	beginReplaceAll {
 		replaceAll = true;
+		^[] // nothing needed (dummy synth)
 	}
 
 	beginStack {

--- a/Classes/StenoStack.sc
+++ b/Classes/StenoStack.sc
@@ -4,7 +4,7 @@ StenoStack {
 	var argStack;
 
 	var dryReadIndex = 0, readIndex = 0, writeIndex = 0, through = 0, <argumentIndex;
-	var nestingDepth = 0;
+	var nestingDepth = 0, replaceAll = false;
 
 
 	*new { |busIndices|
@@ -13,14 +13,14 @@ StenoStack {
 
 	push {
 		// save current args on stack
-		argStack = argStack.add([readIndex, writeIndex, dryReadIndex, through, argumentIndex]);
+		argStack = argStack.add([readIndex, writeIndex, dryReadIndex, through, argumentIndex, replaceAll]);
 		nestingDepth = nestingDepth + 1;
 	}
 
 	pop {
 		// set args for subsequent synths
 		if(nestingDepth < 1) { Error("inconsistent syntax. This should not happen").throw };
-		#readIndex, writeIndex, dryReadIndex, through, argumentIndex = argStack.pop;
+		#readIndex, writeIndex, dryReadIndex, through, argumentIndex, replaceAll = argStack.pop;
 		nestingDepth = nestingDepth - 1;
 	}
 
@@ -89,6 +89,10 @@ StenoStack {
 
 		^args
 
+	}
+
+	beginReplaceAll {
+		replaceAll = true;
 	}
 
 	beginStack {

--- a/Classes/extStenoPlot.sc
+++ b/Classes/extStenoPlot.sc
@@ -1,0 +1,53 @@
++ Steno {
+
+	// this represents the structure of the actual implementation
+	// not complete
+
+	plotStructure { |title = "untitled"|
+		var window, run = true;
+		var in, out, prevNode, curNode;
+		window = Window(title);
+		window.background = Color.black;
+		window.onClose = { run = false };
+		window.drawFunc = {
+			var prevNodes = Array.newClear(busIndices.size);
+			synthList.do { |synth, i|
+				var nodeSize = 20;
+				var args = argList.at(i);
+				var name = this.removePrefix(synth.defName);
+				var mul = Point(
+					window.bounds.width - (nodeSize * 2) / busIndices.size,
+					window.bounds.height - (nodeSize * 2) / synthList.size
+				);
+				if(args.isEmpty.not and: { name != ')' }) {
+					in = busIndices.indexOf(args[1]);
+					//in = busIndices.indexOf(args[5]);
+					out = busIndices.indexOf(args[3]);
+				} {
+					out = out ? 0;
+					in = in ? in;
+				};
+				prevNode = prevNodes[in];
+				curNode = Point(out + 1, i + 1) * mul;
+				prevNodes[out] = curNode;
+				Pen.color = Color.white;
+				Pen.moveTo(curNode);
+				Pen.addOval(Rect.aboutPoint(curNode, nodeSize, nodeSize));
+				Pen.moveTo(curNode);
+				if(name != '?') { Pen.stringAtPoint(name, curNode, Font.sansSerif(nodeSize)) };
+				Pen.moveTo(curNode);
+				prevNode !? { Pen.lineTo(prevNode) };
+			};
+			Pen.stroke;
+		};
+		{ while { run } { window.refresh; 0.05.wait; } }.fork(AppClock)
+		^window.front;
+	}
+
+	dotStructure { |title, attributes, labelAttributes|
+		attributes = attributes ?? { "rankdir=LR;\nfontname=Courier;\nlabel=\"\n\n%\"".format(cmdLine) };
+		labelAttributes = labelAttributes ?? { "fontname=Courier" };
+		^this.cmdLine.stenoDotStructure(title ? cmdLine, attributes, variables.keys, operators, labelAttributes)
+	}
+
+}


### PR DESCRIPTION
This replaces the old "!" implementation by introducing it as an operator that can occupy any depth in the bracket stack.

E.g. 

`-- [(!fi)(fo)(f!a)]` will replace `fi` and `a` (in place).

Needs testing (!)