### PR TITLE
remove unnecessary clutter in `dummyOpeningFunction`

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -514,10 +514,8 @@ Steno {
 		dummyOpeningFunction = {
 			var stenoSignal;
 			stenoSignal = StenoSignal(numChannels);
-			stenoSignal.quelle(nil, true, numChannels);
 			FreeSelfWhenDone.kr(stenoSignal.env); // free synth if gate 0
 
-			stenoSignal.writeToBus;
 		};
 
 		// begin serial: dry = in


### PR DESCRIPTION
not a lot of testing happened on this one (yet); please check/test if correct.