### PR TITLE
remove dryIn from filterOutput

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -463,6 +463,7 @@ Steno {
 		// 	ReplaceOut.ar(stenoSignal.outBus, Silent.ar(numChannels)); // umbrella
 		// 	FreeSelfWhenDone.kr(stenoSignal.env);
 		// };
+		/*
 		dummyOpeningFunction = {
 			var stenoSignal;
 			stenoSignal = StenoSignal(numChannels);
@@ -471,7 +472,7 @@ Steno {
 
 			stenoSignal.writeToBus;
 		};
-
+		*/
 		// begin serial: dry = in
 		/*
 		this.addSynthDef('(', { |in, out, dryIn, mix = 0, through = 0|
@@ -490,8 +491,8 @@ Steno {
 
 		this.addSynthDef('(', routingFunction, force:true);
 
-		this.addSynthDef('[', dummyOpeningFunction, force:true);
-		this.addSynthDef('{', dummyOpeningFunction, force:true);
+		this.addSynthDef('[', dummyFunction, force:true);
+		this.addSynthDef('{', dummyFunction, force:true);
 
 		this.addSynthDef(')', routingFunction, force:true);
 		this.addSynthDef(']', routingFunction, force:true);

--- a/Classes/StenoSignal.sc
+++ b/Classes/StenoSignal.sc
@@ -13,7 +13,7 @@ StenoSignal {
 
 	init {
 		inBus = \in.kr(0);
-		dryIn = \dryIn.kr(0);
+		dryIn = \dryIn.kr(0); // only used for closing brackets
 		input = In.ar(inBus, numChannels).asArray;
 		tailBus = \tailBus.ir(0);
 
@@ -68,7 +68,7 @@ StenoSignal {
 
 	// set filter output
 	filterOutput { |signal, argNumChannels, offset = 0|
-		var gateHappened, dcBlocked, oldSignal, drySignal, tailSignal;
+		var gateHappened, dcBlocked, oldSignal, tailSignal;
 		argNumChannels = min(argNumChannels  ? numChannels, numChannels - offset); // avoid overrun of total channels given
 
 		signal = signal.asArray.keep(argNumChannels);
@@ -89,7 +89,6 @@ StenoSignal {
 
 
 		oldSignal = In.ar(outBus + offset, argNumChannels); // previous signal on bus
-		drySignal = In.ar(dryIn  + offset, argNumChannels); // dry signal (mostly same as oldSignal but may come from another bus)
 		tailSignal = In.ar(tailBus + offset, argNumChannels); // tails from replaced synths
 
 		// TODO: if replace, set mix to 1


### PR DESCRIPTION
Let’s remove dryIn from filterOutput, because it isn’t needed there. It
only makes sense for the last item in a parentheses.

If someone thinks something up to use it in a synth, we can easily add
it to the controls.