### PR TITLE
steno signal closing parenthesis

### DIFF
--- a/Classes/Steno.sc
+++ b/Classes/Steno.sc
@@ -446,7 +446,11 @@ Steno {
 			]);   // fade old input according to gate, signal is supposed to fade out itself.
 
 			FreeSelfWhenDone.kr(stenoSignal.env); // free synth if gate 0
-			ReplaceOut.ar(stenoSignal.inBus, Silent.ar(numChannels)); // clean up: overwrite channel with zero.
+
+			// clean up: overwrite channel with zero.
+			// probably not needed, because fresh signal overwrites it anyhow.
+			// I leave the corrected implementation here, in case it turns out we still need it
+			// XOut.ar(stenoSignal.inBus, stenoSignal.gate, Silent.ar(numChannels));
 
 			stenoSignal.addOutput(signal);
 			stenoSignal.writeToBus;


### PR DESCRIPTION
The closing parentheses should only clean up after themselves as long
as its gate is on. But anyhow, this might have been too prudent. So I
corrected it and also commented it out.

This fixes #25.

Needs tough testing with complicated nested graphs.